### PR TITLE
Allow using average score

### DIFF
--- a/anilist/async_client.py
+++ b/anilist/async_client.py
@@ -97,7 +97,7 @@ class Client:
         else:
             raise TypeError("There is no such content type.")
 
-    async def search_anime(self, query: str, limit: int) -> Optional[Anime]:
+    async def search_anime(self, query: str, limit: int, avg_score: int) -> Optional[Anime]:
         need_to_close = False
         if not self.httpx:
             self.httpx = httpx.AsyncClient(http2=True)
@@ -108,6 +108,7 @@ class Client:
                 query=ANIME_SEARCH_QUERY,
                 variables=dict(
                     search=query,
+                    score=avg_score,
                     per_page=limit,
                     MediaType="ANIME",
                 ),

--- a/anilist/async_client.py
+++ b/anilist/async_client.py
@@ -67,7 +67,7 @@ class Client:
                 f"limit argument must be a string, not '{limit.__class__.__name__}'"
             )
         if content_type == "anime":
-            return await self.search_anime(query=query, limit=limit)
+            return await self.search_anime(query=query, limit=limit, avg_score=avg_score)
         elif content_type in ["char", "character"]:
             return await self.search_character(query=query, limit=limit)
         elif content_type == "manga":

--- a/anilist/sync_client.py
+++ b/anilist/sync_client.py
@@ -48,7 +48,7 @@ class Client:
         self.httpx = None
         return None
 
-    def search(self, query: str, content_type: str = "anime", limit: int = 10):
+    def search(self, query: str, content_type: str = "anime", limit: int = 10, avg_score: int = 0):
         if isinstance(content_type, str):
             content_type = content_type.lower()
         else:
@@ -66,7 +66,7 @@ class Client:
                 f"limit argument must be a string, not '{limit.__class__.__name__}'"
             )
         if content_type == "anime":
-            return self.search_anime(query=query, limit=limit)
+            return self.search_anime(query=query, limit=limit, avg_score=avg_score)
         elif content_type in ["char", "character"]:
             return self.search_character(query=query, limit=limit)
         elif content_type == "manga":
@@ -96,7 +96,7 @@ class Client:
         else:
             raise TypeError("There is no such content type.")
 
-    def search_anime(self, query: str, limit: int) -> Optional[Anime]:
+    def search_anime(self, query: str, limit: int, avg_score: int = 0) -> Optional[Anime]:
         if not self.httpx:
             self.httpx = httpx.Client()
         response = self.httpx.post(
@@ -105,12 +105,14 @@ class Client:
                 query=ANIME_SEARCH_QUERY,
                 variables=dict(
                     search=query,
+                    score=avg_score,
                     per_page=limit,
                     MediaType="ANIME",
                 ),
             ),
             headers=HEADERS,
         )
+
         data = response.json()
         if data["data"]:
             try:

--- a/anilist/utils.py
+++ b/anilist/utils.py
@@ -28,9 +28,9 @@ HEADERS = {
 
 # Search
 ANIME_SEARCH_QUERY = """
-query($id: Int, $per_page: Int, $search: String) {
+query($id: Int, $per_page: Int, $search: String, $score: Int) {
     Page(page: 1, perPage: $per_page) {
-        media(id: $id, search: $search, type: ANIME, sort: POPULARITY_DESC) {
+        media(id: $id, search: $search, averageScore_greater: $score, type: ANIME, sort: POPULARITY_DESC) {
             id
             title {
                 romaji


### PR DESCRIPTION
I've added the ability to add an average score to the anime search feature. It defaults to `0` and due to the GraphQL query being `averageScore_greater` this means the overall effect of not using the variable is to show the same results. 
The `score` is out of 100.

Making it backwards compatible.

Here's an example of it in use though:

```python
anc = anilist.Client()

# average score greater than 70 with the query term "Seraph"
results = anc.search_anime('Seraph', 10, 70)
print(len(results)) # 5

# average score greater than 75 with the query term "Seraph"
results = anc.search_anime('Seraph', 10, 75)
print(len(results)) # 1
```