### PR TITLE
Large refactoring to simplify code and remove duplicate code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 1.1.0 (July 23rd, 2023)
+
+Large refactoring to remove duplicate code.
+
+### Changed
+
+- Rebase all classes to be subclasses of a main "Object" class, or "Hashable" if the class has an id. This was to avoid the repetitive __repr__, __str__, and raw() definitions in every class, as well as allow things like implementation of __eq__ to all classes by writing it in only one place. ([commit](https://github.com/r-hensley/python-anilist/commit/15d57c753c7b5eb6624bdbfb719f82fc68f743db))
+- Add some basic info to the readme, as well as an example.
+- Consolidate duplicated code between the synhronous and asynchronous files into one "client_process.py" file ([commit](https://github.com/r-hensley/python-anilist/commit/a568ac77883ee2225287df849a59dea7cd658253))
+- The IDs being used for one of the tests in the test file were no longer found on the tested user's profile, so they have been updated to a new ID for the sake of a successful test ([commit](https://github.com/r-hensley/python-anilist/commit/b0825364e22d2ad3ee9f18e2cb1f302081e52e00))
+- Consolidate API calls into a single "api_query()" function ([commit](https://github.com/r-hensley/python-anilist/commit/4066a5371a1573ab6e28e1ab5d6901af678ba184))
+- Changed all the "try ... except ... pass" blocks to "try ... except ... raise" to ensure proper propagation of errors. If a user wishes to ignore all errors they should do that in their program rather than the library suppressing all errors with no logs ([commit](https://github.com/r-hensley/python-anilist/commit/cba69086587ac164d5fc55eddccc58f9e5680b7b))
+
 ## 1.0.9 (February 16th, 2022)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,9 +65,15 @@ import anilist
 
 client = anilist.Client()
 
-madoka_list = client.search_anime("madoka", limit=10)  # returns list of up to 10 Anime object results
-madoka = madoka_list[0][0][0]  # assuming you want the first search result
-print(madoka.title, madoka.id)
+# a search returns a tuple (A, B) with A being the main data of the search,
+# and B being a PageInfo object containing info about the page of the search result
+search_result: tuple[list, PageInfo] = client.search_anime("madoka", limit=10)
+
+madoka_list: list[Anime] = search_result[0]  # taking "A" from the above tuple, this is a list of "Anime" objects
+
+madoka_magica: Anime = madoka_list[0]  # this chooses the first anime in the list of search results
+
+print(madoka.title, madoka.id)  # print that anime's title and anilist.co ID
 
 >>> {'romaji': 'Mahou Shoujo Madoka☆Magica', 'english': 'Puella Magi Madoka Magica', 'native': '魔法少女まどか☆マギカ'} 9756
 ```
@@ -82,7 +88,7 @@ print(madoka.title, madoka.id)
 
 ## License
 
-Copyright © 2021-2022 [AmanoTeam](https://github.com/AmanoTeam)
+Copyright © 2021-2023 [AmanoTeam](https://github.com/AmanoTeam)
 and the python-anilist contributors
 
 Licensed under the [Expat/MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ etc.
 Example code usage:
 
 ```py
-from pythonanilist import anilist
+import anilist
 
 client = anilist.Client()
 
 madoka_list = client.search_anime("madoka", limit=10)  # returns list of up to 10 Anime object results
-madoka = madoka_list[0][0][0]  # assume you want the first search result
+madoka = madoka_list[0][0][0]  # assuming you want the first search result
 print(madoka.title, madoka.id)
 
 >>> {'romaji': 'Mahou Shoujo Madoka☆Magica', 'english': 'Puella Magi Madoka Magica', 'native': '魔法少女まどか☆マギカ'} 9756

--- a/README.md
+++ b/README.md
@@ -33,6 +33,44 @@ For the latest development version:
 python3 -m pip install git+https://github.com/AmanoTeam/python-anilist.git#egg=python-anilist
 ```
 
+## Basic starting guide
+
+First, import the module
+```py
+import anilist
+```
+
+Next, define the client to interact with the API
+
+```py
+client = anilist.Client()
+```
+
+You can search for the name of something on the site using:
+- `client.search_user(name, limit=10)`
+- `client.search_anime(name, limit=10)`
+- `client.search_manga(name, limit=10)`
+- `client.search_character(name, limit=10)`
+- `client.search_staff(name, limit=10)`
+
+If you know the ID of something, then use the get() commands instead:
+- `client.get_user(ID)`
+- `client.get_anime(ID)`
+etc.
+
+Example code usage:
+
+```py
+from pythonanilist import anilist
+
+client = anilist.Client()
+
+madoka_list = client.search_anime("madoka", limit=10)  # returns list of up to 10 Anime object results
+madoka = madoka_list[0][0][0]  # assume you want the first search result
+print(madoka.title, madoka.id)
+
+>>> {'romaji': 'Mahou Shoujo Madoka☆Magica', 'english': 'Puella Magi Madoka Magica', 'native': '魔法少女まどか☆マギカ'} 9756
+```
 ## What's left to do?
 
 - Write the API Documentation.

--- a/anilist/async_client.py
+++ b/anilist/async_client.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 import httpx
 
@@ -43,6 +43,12 @@ from .utils import (
 )
 
 
+async def api_query(query, variables, url=API_URL, headers=HEADERS):
+    async with httpx.AsyncClient(http2=True) as session:
+        response = await session.post(url=url, json=dict(query=query, variables=variables), headers=headers)
+    return response
+
+
 class Client:
     def __init__(self):
         self.httpx = None
@@ -57,12 +63,12 @@ class Client:
         return None
 
     async def search(
-        self,
-        query: str,
-        content_type: str = "anime",
-        page: int = 1,
-        limit: int = 10,
-        pagination: bool = False,
+            self,
+            query: str,
+            content_type: str = "anime",
+            page: int = 1,
+            limit: int = 10,
+            pagination: bool = False,
     ) -> Optional[
         Union[
             tuple[Union[Anime, Manga, Character, Staff, User], PageInfo],
@@ -123,12 +129,12 @@ class Client:
         return search
 
     async def get(
-        self,
-        id: Union[int, str],
-        content_type: str = "anime",
-        page: int = 1,
-        limit: int = 25,
-        pagination: bool = False,
+            self,
+            id: Union[int, str],
+            content_type: str = "anime",
+            page: int = 1,
+            limit: int = 25,
+            pagination: bool = False,
     ) -> Optional[tuple[Union[Anime, Manga, Character, Staff, List[MediaList], User], PageInfo]]:
         """Gets specified item from given id.
 
@@ -198,270 +204,90 @@ class Client:
         else:
             raise TypeError("There is no such content type.")
 
+    @staticmethod
     async def search_anime(
-        self, query: str, limit: int, page: int = 1
+            query: str, limit: int, page: int = 1
     ) -> Optional[tuple[list[Anime], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=ANIME_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                    MediaType="ANIME",
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(ANIME_SEARCH_QUERY,
+                                   dict(search=query, page=page, per_page=limit, MediaType="ANIME"))
         data: Optional[dict] = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_search_anime(data)
 
+    @staticmethod
     async def search_manga(
-        self, query: str, limit: int, page: int = 1
+            query: str, limit: int, page: int = 1
     ) -> Optional[tuple[list[Manga], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MANGA_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                    MediaType="MANGA",
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(MANGA_SEARCH_QUERY,
+                                   dict(search=query, page=page, per_page=limit, MediaType="MANGA"))
         data: dict = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_search_manga(data)
 
+    @staticmethod
     async def search_character(
-        self, query: str, limit: int, page: int = 1
+            query: str, limit: int, page: int = 1
     ) -> Optional[tuple[list[Character], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=CHARACTER_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(CHARACTER_SEARCH_QUERY, dict(search=query, page=page, per_page=limit))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_search_character(data)
 
+    @staticmethod
     async def search_staff(
-        self, query: str, limit: int, page: int = 1
+            query: str, limit: int, page: int = 1
     ) -> Optional[tuple[list[Staff], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=STAFF_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(STAFF_SEARCH_QUERY, dict(search=query, page=page, per_page=limit))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_search_staff(data)
 
+    @staticmethod
     async def search_user(
-        self, query: str, limit: int, page: int = 1
+            query: str, limit: int, page: int = 1
     ) -> Optional[tuple[list[User], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=USER_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(USER_SEARCH_QUERY, dict(search=query, page=page, per_page=limit))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_search_user(data)
 
-    async def get_anime(self, id: int) -> Optional[Anime]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=ANIME_GET_QUERY,
-                variables=dict(
-                    id=id,
-                    MediaType="ANIME",
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_anime(id: int) -> Optional[Anime]:
+        response = await api_query(ANIME_GET_QUERY, dict(id=id, MediaType="ANIME"))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_anime(data)
 
-    async def get_manga(self, id: int) -> Optional[Manga]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MANGA_GET_QUERY,
-                variables=dict(
-                    id=id,
-                    MediaType="MANGA",
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_manga(id: int) -> Optional[Manga]:
+        response = await api_query(MANGA_GET_QUERY, dict(id=id, MediaType="MANGA"))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_manga(data)
 
-    async def get_character(self, id: int) -> Optional[Character]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=CHARACTER_GET_QUERY,
-                variables=dict(
-                    id=id,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_character(id: int) -> Optional[Character]:
+        response = await api_query(CHARACTER_GET_QUERY, dict(id=id))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_character(data)
 
-    async def get_staff(self, id: int) -> Optional[Staff]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=STAFF_GET_QUERY,
-                variables=dict(
-                    id=id,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_staff(id: int) -> Optional[Staff]:
+        response = await api_query(STAFF_GET_QUERY, dict(id=id))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_staff(data)
 
-    async def get_user(self, name: str) -> Optional[User]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=USER_GET_QUERY,
-                variables=dict(
-                    name=name,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_user(name: str) -> Optional[User]:
+        response = await api_query(USER_GET_QUERY, dict(name=name))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_user(data)
 
+    @staticmethod
     async def get_list(
-        self, user_id: int, limit: int, page: int = 1, content_type: str = "anime"
+            user_id: int, limit: int, page: int = 1, content_type: str = "anime"
     ) -> Optional[tuple[List[MediaList], List[MediaList]]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-
         is_manga = "manga" in content_type
-
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=LIST_GET_QUERY_ANIME if not is_manga else LIST_GET_QUERY_MANGA,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(LIST_GET_QUERY_ANIME if not is_manga else LIST_GET_QUERY_MANGA,
+                                   dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
-
         return process_get_list(data, content_type)
 
-    async def get_list_item(self, name: str, id: int) -> Optional[MediaList]:
+    @staticmethod
+    async def get_list_item(name: str, id: int) -> Optional[MediaList]:
         """Returns list item from user.
 
         Args:
@@ -471,34 +297,17 @@ class Client:
         Returns:
             Optional[MediaList]: List item.
         """
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=LIST_ITEM_GET_QUERY,
-                variables=dict(
-                    name=name,
-                    id=id,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(LIST_ITEM_GET_QUERY, dict(name=name, id=id))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_list_item(data)
 
     async def get_activity(
-        self,
-        id: Union[int, str],
-        content_type: str = "anime",
-        page: int = 1,
-        limit: int = 25,
-        pagination: bool = False,
+            self,
+            id: Union[int, str],
+            content_type: str = "anime",
+            page: int = 1,
+            limit: int = 25,
+            pagination: bool = False,
     ) -> Union[Optional[tuple[ListActivity, PageInfo]], Optional[ListActivity]]:
         """Returns activity of a user.
 
@@ -558,135 +367,41 @@ class Client:
             return activity, pages
         return activity
 
+    @staticmethod
     async def get_anime_activity(
-        self, user_id: int, limit: int, page: int = 1
+            user_id: int, limit: int, page: int = 1
     ) -> Optional[tuple[list[ListActivity], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=LIST_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                    activity_type="ANIME_LIST",
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = await api_query(LIST_ACTIVITY_QUERY,
+                                   dict(user_id=user_id, page=page, per_page=limit, activity_type="ANIME_LIST"))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_anime_activity(data)
 
-    async def get_manga_activity(
-        self, user_id: int, limit: int, page: int = 1
-    ) -> Optional[tuple[list[ListActivity], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        MANGA_ACTIVITY_QUERY = LIST_ACTIVITY_QUERY.replace(
-            "episodes", "chapters\nvolumes"
-        )
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MANGA_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                    activity_type="MANGA_LIST",
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_manga_activity(user_id: int, limit: int, page: int = 1
+                                 ) -> Optional[tuple[list[ListActivity], PageInfo]]:
+        MANGA_ACTIVITY_QUERY = LIST_ACTIVITY_QUERY.replace("episodes", "chapters\nvolumes")
+        response = await api_query(MANGA_ACTIVITY_QUERY,
+                                   dict(user_id=user_id, page=page, per_page=limit, activity_type="MANGA_LIST"))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_manga_activity(data)
 
-    async def get_text_activity(
-        self, user_id: int, limit: int, page: int = 1
-    ) -> Optional[tuple[list[TextActivity], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=TEXT_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_text_activity(user_id: int, limit: int, page: int = 1
+                                ) -> Optional[tuple[list[TextActivity], PageInfo]]:
+        response = await api_query(TEXT_ACTIVITY_QUERY, dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
         return process_get_text_activity(data)
 
-    async def get_message_activity(
-        self, user_id: int, limit: int, page: int = 1
-    ) -> Optional[tuple[list[TextActivity], PageInfo]]:
-        need_to_close = False
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MESSAGE_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_message_activity(user_id: int, limit: int, page: int = 1
+                                   ) -> Optional[tuple[list[TextActivity], PageInfo]]:
+        response = await api_query(MESSAGE_ACTIVITY_QUERY, dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
-
         return process_get_message_activity(data)
 
-    async def get_message_activity_sent(
-            self, user_id: int, limit: int, page: int = 1
-    ) -> Optional[tuple[list[TextActivity], PageInfo]]:
-        need_to_close = False
-
-        if not self.httpx:
-            self.httpx = httpx.AsyncClient(http2=True)
-            need_to_close = True
-        response = await self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MESSAGE_ACTIVITY_QUERY_SENT,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    async def get_message_activity_sent(user_id: int, limit: int, page: int = 1
+                                        ) -> Optional[tuple[list[TextActivity], PageInfo]]:
+        response = await api_query(MESSAGE_ACTIVITY_QUERY_SENT, dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
-        if need_to_close:
-            await self.httpx.aclose()
-            self.httpx = None
-
         return process_get_message_activity_sent(data)

--- a/anilist/async_client.py
+++ b/anilist/async_client.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple, Union
 
 import httpx
 
-from anilist.types import (
+from .types import (
     Anime,
     Character,
     FavouritesUnion,
@@ -23,7 +23,7 @@ from anilist.types import (
     TextActivity,
     User,
 )
-from anilist.utils import (
+from .utils import (
     ANIME_GET_QUERY,
     ANIME_SEARCH_QUERY,
     API_URL,

--- a/anilist/client_process.py
+++ b/anilist/client_process.py
@@ -180,7 +180,7 @@ def process_search_anime(data: Optional[dict]) -> Optional[tuple[list[Anime], Pa
             ]
             return results, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -201,7 +201,7 @@ def process_search_manga(data: Optional[dict]) -> Optional[tuple[list[Manga], Pa
             ]
             return results, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -221,7 +221,7 @@ def process_search_character(data: dict) -> Optional[tuple[list[Character], Page
             ]
             return results, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -239,7 +239,7 @@ def process_search_staff(data) -> Optional[tuple[list[Staff], PageInfo]]:
             results = [Staff(id=item["id"], name=item["name"]) for item in items]
             return results, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -260,7 +260,7 @@ def process_search_user(data) -> Optional[tuple[list[User], PageInfo]]:
             ]
             return results, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -317,7 +317,7 @@ def process_get_anime(data) -> Optional[Anime]:
                 relations=item["relations"],
             )
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -373,7 +373,7 @@ def process_get_manga(data) -> Optional[Manga]:
                 relations=item["relations"],
             )
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -383,7 +383,7 @@ def process_get_character(data) -> Optional[Character]:
             item = data["data"]["Character"]
             return construct_character_object(item)
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -393,7 +393,7 @@ def process_get_staff(data) -> Optional[Staff]:
             item = data["data"]["Staff"]
             return construct_staff_object(item)
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -467,7 +467,7 @@ def process_get_user(data) -> Optional[User]:
                 statistics=statistics,
             )
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -531,7 +531,7 @@ def process_get_list(data: dict, content_type: str) -> Optional[tuple[list[Media
             return res, pagination
 
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -552,7 +552,7 @@ def process_get_list_item(data: dict) -> Optional[MediaList]:
                 create_date=item["createdAt"],
             )
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -587,7 +587,7 @@ def process_get_anime_activity(data) -> Optional[tuple[list[ListActivity], PageI
 
             return result, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -621,7 +621,7 @@ def process_get_manga_activity(data: dict) -> Optional[tuple[list[ListActivity],
 
             return result, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
@@ -657,11 +657,11 @@ def process_get_text_activity(data: dict) -> Optional[tuple[list[TextActivity], 
 
             return result, pagination
         except Exception:
-            pass
+            raise
     return None
 
 
-def process_get_message_activity(data: dict) -> Optional[tuple[list[TextActivity], PageInfo]]:
+def process_get_message_activity(data: dict) -> Optional[list[TextActivity]]:
     result = []
 
     if data["data"]:
@@ -691,7 +691,7 @@ def process_get_message_activity(data: dict) -> Optional[tuple[list[TextActivity
                     )
                 )
         except Exception:
-            pass
+            raise
 
     if len(result):
         return result

--- a/anilist/client_process.py
+++ b/anilist/client_process.py
@@ -1,0 +1,703 @@
+from typing import Optional
+
+from .types import (
+    Anime,
+    Character,
+    FavouritesUnion,
+    ListActivity,
+    Manga,
+    MediaList,
+    PageInfo,
+    Ranking,
+    Staff,
+    Statistic,
+    StatisticsUnion,
+    Studio,
+    TextActivity,
+    User,
+)
+
+
+def construct_manga_object(media) -> Manga:
+    manga = Manga(
+        id=media["id"],
+        title=media["title"],
+        url=media["siteUrl"],
+        chapters=media["chapters"],
+        description=media["description"],
+        status=media["status"],
+        genres=media["genres"],
+        is_adult=media["isAdult"],
+        tags=media["tags"],
+        studios=media["studios"],
+        start_date=media["startDate"],
+        end_date=media["endDate"],
+        season=dict(
+            name=media["season"],
+            year=media["seasonYear"],
+            number=media["seasonInt"],
+        ),
+        country=media["countryOfOrigin"],
+        cover=media["coverImage"],
+        banner=media["bannerImage"],
+        source=media["source"],
+        hashtag=media["hashtag"],
+        synonyms=media["synonyms"],
+        score=dict(
+            mean=media["meanScore"],
+            average=media["averageScore"],
+        ),
+        next_airing=media["nextAiringEpisode"],
+        trailer=media["trailer"],
+        staff=media["staff"],
+        characters=media["characters"],
+        volumes=media["volumes"],
+        popularity=media["popularity"],
+        rankings=[
+            Ranking(
+                type=i["type"],
+                all_time=i["allTime"],
+                format=i["format"],
+                rank=i["rank"],
+                year=i["year"],
+                season=i["season"],
+            )
+            for i in media["rankings"]
+        ],
+    )
+
+    return manga
+
+
+def construct_anime_object(media: dict) -> Anime:
+    anime = Anime(
+        id=media["id"],
+        title=media["title"],
+        url=media["siteUrl"],
+        episodes=media["episodes"],
+        description=media["description"],
+        format=media["format"],
+        status=media["status"],
+        duration=media["duration"],
+        genres=media["genres"],
+        is_adult=media["isAdult"],
+        tags=media["tags"],
+        studios=media["studios"],
+        start_date=media["startDate"],
+        end_date=media["endDate"],
+        season=dict(
+            name=media["season"],
+            year=media["seasonYear"],
+            number=media["seasonInt"],
+        ),
+        country=media["countryOfOrigin"],
+        cover=media["coverImage"],
+        banner=media["bannerImage"],
+        source=media["source"],
+        hashtag=media["hashtag"],
+        synonyms=media["synonyms"],
+        score=dict(
+            mean=media["meanScore"],
+            average=media["averageScore"],
+        ),
+        next_airing=media["nextAiringEpisode"],
+        trailer=media["trailer"],
+        staff=media["staff"],
+        characters=media["characters"],
+        popularity=media["popularity"],
+        rankings=[
+            Ranking(
+                type=i["type"],
+                all_time=i["allTime"],
+                format=i["format"],
+                rank=i["rank"],
+                year=i["year"],
+                season=i["season"],
+            )
+            for i in media["rankings"]
+        ],
+    )
+
+    return anime
+
+
+def construct_character_object(media: dict) -> Character:
+    return Character(
+        id=media["id"],
+        name=media["name"],
+        image=media["image"],
+        url=media["siteUrl"],
+        favorites=media["favourites"],
+        description=media["description"],
+        media=media["media"],
+        is_favorite=media["isFavourite"],
+    )
+
+
+def construct_staff_object(media: dict) -> Staff:
+    return Staff(
+        id=media["id"],
+        name=media["name"],
+        language=media["languageV2"],
+        image=media["image"],
+        description=media["description"],
+        gender=media["gender"],
+        birth_date=media["dateOfBirth"],
+        death_date=media["dateOfDeath"],
+        url=media["siteUrl"],
+        favorites=media["favourites"],
+        occupations=media["primaryOccupations"],
+        age=media["age"],
+        years_active=media["yearsActive"],
+        home_town=media["homeTown"],
+    )
+
+
+def construct_studio_object(media: dict) -> Studio:
+    return Studio(
+        id=media["id"],
+        name=media["name"],
+        is_animation_studio=media["isAnimationStudio"],
+        url=media["siteUrl"],
+        favourites=media["favourites"],
+    )
+
+
+def process_search_anime(data: Optional[dict]) -> Optional[tuple[list[Anime], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["media"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            results = [
+                Anime(id=item["id"], title=item["title"], url=item["siteUrl"])
+                for item in items
+            ]
+            return results, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_search_manga(data: Optional[dict]) -> Optional[tuple[list[Manga], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["media"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            results = [
+                Manga(id=item["id"], title=item["title"], url=item["siteUrl"])
+                for item in items
+            ]
+            return results, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_search_character(data: dict) -> Optional[tuple[list[Character], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["characters"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            results = [
+                Character(id=item["id"], name=item["name"]) for item in items
+            ]
+            return results, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_search_staff(data) -> Optional[tuple[list[Staff], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["staff"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            results = [Staff(id=item["id"], name=item["name"]) for item in items]
+            return results, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_search_user(data) -> Optional[tuple[list[User], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["users"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            results = [
+                User(id=item["id"], name=item["name"], image=item["avatar"])
+                for item in items
+            ]
+            return results, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_get_anime(data) -> Optional[Anime]:
+    if data["data"]:
+        try:
+            item = data["data"]["Page"]["media"][0]
+            return Anime(
+                id=item["id"],
+                title=item["title"],
+                url=item["siteUrl"],
+                episodes=item["episodes"],
+                description=item["description"],
+                format=item["format"],
+                status=item["status"],
+                duration=item["duration"],
+                genres=item["genres"],
+                is_adult=item["isAdult"],
+                tags=item["tags"],
+                studios=item["studios"],
+                start_date=item["startDate"],
+                end_date=item["endDate"],
+                season=dict(
+                    name=item["season"],
+                    year=item["seasonYear"],
+                    number=item["seasonInt"],
+                ),
+                country=item["countryOfOrigin"],
+                cover=item["coverImage"],
+                banner=item["bannerImage"],
+                source=item["source"],
+                hashtag=item["hashtag"],
+                synonyms=item["synonyms"],
+                score=dict(
+                    mean=item["meanScore"],
+                    average=item["averageScore"],
+                ),
+                next_airing=item["nextAiringEpisode"],
+                trailer=item["trailer"],
+                staff=item["staff"],
+                characters=item["characters"],
+                popularity=item["popularity"],
+                rankings=[
+                    Ranking(
+                        type=i["type"],
+                        all_time=i["allTime"],
+                        format=i["format"],
+                        rank=i["rank"],
+                        year=i["year"],
+                        season=i["season"],
+                    )
+                    for i in item["rankings"]
+                ],
+                relations=item["relations"],
+            )
+        except Exception:
+            pass
+    return None
+
+
+def process_get_manga(data) -> Optional[Manga]:
+    if data["data"]:
+        try:
+            item = data["data"]["Page"]["media"][0]
+            return Manga(
+                id=item["id"],
+                title=item["title"],
+                url=item["siteUrl"],
+                chapters=item["chapters"],
+                description=item["description"],
+                status=item["status"],
+                genres=item["genres"],
+                is_adult=item["isAdult"],
+                tags=item["tags"],
+                studios=item["studios"],
+                start_date=item["startDate"],
+                end_date=item["endDate"],
+                season=dict(
+                    name=item["season"],
+                    year=item["seasonYear"],
+                    number=item["seasonInt"],
+                ),
+                country=item["countryOfOrigin"],
+                cover=item["coverImage"],
+                banner=item["bannerImage"],
+                source=item["source"],
+                hashtag=item["hashtag"],
+                synonyms=item["synonyms"],
+                score=dict(
+                    mean=item["meanScore"],
+                    average=item["averageScore"],
+                ),
+                next_airing=item["nextAiringEpisode"],
+                trailer=item["trailer"],
+                staff=item["staff"],
+                characters=item["characters"],
+                volumes=item["volumes"],
+                popularity=item["popularity"],
+                rankings=[
+                    Ranking(
+                        type=i["type"],
+                        all_time=i["allTime"],
+                        format=i["format"],
+                        rank=i["rank"],
+                        year=i["year"],
+                        season=i["season"],
+                    )
+                    for i in item["rankings"]
+                ],
+                relations=item["relations"],
+            )
+        except Exception:
+            pass
+    return None
+
+
+def process_get_character(data) -> Optional[Character]:
+    if data["data"]:
+        try:
+            item = data["data"]["Character"]
+            return construct_character_object(item)
+        except Exception:
+            pass
+    return None
+
+
+def process_get_staff(data) -> Optional[Staff]:
+    if data["data"]:
+        try:
+            item = data["data"]["Staff"]
+            return construct_staff_object(item)
+        except Exception:
+            pass
+    return None
+
+
+def process_get_user(data) -> Optional[User]:
+    if data["data"]:
+        try:
+            item = data["data"]["User"]
+
+            favourites = FavouritesUnion(
+                anime=[construct_anime_object(i) for i in item["favourites"]["anime"]["nodes"]],
+                manga=[construct_manga_object(i) for i in item["favourites"]["manga"]["nodes"]],
+                characters=[construct_character_object(i) for i in item["favourites"]["characters"]["nodes"]],
+                staff=[construct_staff_object(i) for i in item["favourites"]["staff"]["nodes"]],
+                studios=[construct_studio_object(i) for i in item["favourites"]["studios"]["nodes"]],
+            )
+
+            stat_anime = item["statistics"]["anime"]
+            stat_manga = item["statistics"]["manga"]
+
+            statistics = StatisticsUnion(
+                anime=Statistic(
+                    count=stat_anime["count"],
+                    mean_score=stat_anime["meanScore"],
+                    minutes_watched=stat_anime["minutesWatched"],
+                    episodes_watched=stat_anime["episodesWatched"],
+                    statuses=[
+                        [stat["status"], stat["count"]]
+                        for stat in stat_anime["statuses"]
+                    ],
+                    genres=[
+                        [genre["genre"], genre["count"]]
+                        for genre in stat_anime["genres"]
+                    ],
+                    tags=[
+                        [tag["tag"]["name"], tag["count"]]
+                        for tag in stat_anime["tags"]
+                    ],
+                ),
+                manga=Statistic(
+                    count=stat_manga["count"],
+                    mean_score=stat_manga["meanScore"],
+                    chapters_read=stat_manga["chaptersRead"],
+                    volumes_read=stat_manga["volumesRead"],
+                    statuses=[
+                        [stat["status"], stat["count"]]
+                        for stat in stat_manga["statuses"]
+                    ],
+                    genres=[
+                        [genre["genre"], genre["count"]]
+                        for genre in stat_manga["genres"]
+                    ],
+                    tags=[
+                        [tag["tag"]["name"], tag["count"]]
+                        for tag in stat_manga["tags"]
+                    ],
+                ),
+            )
+
+            return User(
+                id=item["id"],
+                name=item["name"],
+                created_at=item["createdAt"],
+                updated_at=item["updatedAt"],
+                image=item["avatar"],
+                url=item["siteUrl"],
+                about=item["about"],
+                donator_tier=item["donatorTier"],
+                donator_badge=item["donatorBadge"],
+                profile_color=item["options"]["profileColor"],
+                favourites=favourites,
+                statistics=statistics,
+            )
+        except Exception:
+            pass
+    return None
+
+
+def process_get_list(data: dict, content_type: str) -> Optional[tuple[list[MediaList], PageInfo]]:
+    is_manga = "manga" in content_type
+    res = []
+    if data["data"]:
+        try:
+            if not is_manga:
+                pg = data["data"]["anime"]["pageInfo"]
+            else:
+                pg = data["data"]["manga"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=pg["total"],
+                current=pg["currentPage"],
+                last=pg["lastPage"],
+            )
+
+            if not is_manga:
+                for item in data["data"]["anime"]["mediaList"]:
+                    media = item["media"]
+                    anime = construct_anime_object(media)
+
+                    res.append(
+                        MediaList(
+                            id=item["id"],
+                            status=item["status"],
+                            score=item["score"],
+                            progress=item["progress"],
+                            repeat=item["repeat"],
+                            priority=item["priority"],
+                            start_date=item["startedAt"],
+                            complete_date=item["completedAt"],
+                            update_date=item["updatedAt"],
+                            create_date=item["createdAt"],
+                            media=anime,
+                        )
+                    )
+
+            if is_manga:
+                for item in data["data"]["manga"]["mediaList"]:
+                    media = item["media"]
+                    manga = construct_manga_object(media)
+
+                    res.append(
+                        MediaList(
+                            id=item["id"],
+                            status=item["status"],
+                            score=item["score"],
+                            progress=item["progress"],
+                            repeat=item["repeat"],
+                            priority=item["priority"],
+                            start_date=item["startedAt"],
+                            complete_date=item["completedAt"],
+                            update_date=item["updatedAt"],
+                            create_date=item["createdAt"],
+                            media=manga,
+                        )
+                    )
+
+            return res, pagination
+
+        except Exception:
+            pass
+    return None
+
+
+def process_get_list_item(data: dict) -> Optional[MediaList]:
+    if data["data"]:
+        try:
+            item = data["data"]["MediaList"]
+            return MediaList(
+                id=item["id"],
+                status=item["status"],
+                score=item["score"],
+                progress=item["progress"],
+                repeat=item["repeat"],
+                priority=item["priority"],
+                start_date=item["startedAt"],
+                complete_date=item["completedAt"],
+                update_date=item["updatedAt"],
+                create_date=item["createdAt"],
+            )
+        except Exception:
+            pass
+    return None
+
+
+def process_get_anime_activity(data) -> Optional[tuple[list[ListActivity], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["activities"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            result = []
+
+            for item in items:
+                media = item["media"]
+
+                anime = construct_anime_object(media)
+
+                result.append(
+                    ListActivity(
+                        id=item["id"],
+                        status=item["status"],
+                        progress=item["progress"],
+                        url=item["siteUrl"],
+                        date=item["createdAt"],
+                        media=anime,
+                    )
+                )
+
+            return result, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_get_manga_activity(data: dict) -> Optional[tuple[list[ListActivity], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["activities"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            result = []
+
+            for item in items:
+                media = item["media"]
+                manga = construct_manga_object(media)
+
+                result.append(
+                    ListActivity(
+                        id=item["id"],
+                        status=item["status"],
+                        progress=item["progress"],
+                        url=item["siteUrl"],
+                        date=item["createdAt"],
+                        media=manga,
+                    )
+                )
+
+            return result, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_get_text_activity(data: dict) -> Optional[tuple[list[TextActivity], PageInfo]]:
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["activities"]
+            page = data["data"]["Page"]["pageInfo"]
+            pagination = PageInfo(
+                total_items=page["total"],
+                current=page["currentPage"],
+                last=page["lastPage"],
+            )
+
+            result = []
+
+            for item in items:
+                result.append(
+                    TextActivity(
+                        id=item["id"],
+                        reply_count=item["replyCount"],
+                        text=item["text"],
+                        text_html=item["textHtml"],
+                        url=item["siteUrl"],
+                        date=item["createdAt"],
+                        user=User(
+                            id=item["user"]["id"],
+                            name=item["user"]["name"],
+                            image=item["user"]["avatar"],
+                        ),
+                    )
+                )
+
+            return result, pagination
+        except Exception:
+            pass
+    return None
+
+
+def process_get_message_activity(data: dict) -> Optional[tuple[list[TextActivity], PageInfo]]:
+    result = []
+
+    if data["data"]:
+        try:
+            items = data["data"]["Page"]["activities"]
+            result = []
+
+            for item in items:
+                result.append(
+                    TextActivity(
+                        id=item["id"],
+                        reply_count=item["replyCount"],
+                        text=item["text"],
+                        text_html=item["textHtml"],
+                        url=item["siteUrl"],
+                        date=item["createdAt"],
+                        user=User(
+                            id=item["messenger"]["id"],
+                            name=item["messenger"]["name"],
+                            image=item["messenger"]["avatar"],
+                        ),
+                        recipient=User(
+                            id=item["recipient"]["id"],
+                            name=item["recipient"]["name"],
+                            image=item["recipient"]["avatar"],
+                        ),
+                    )
+                )
+        except Exception:
+            pass
+
+    if len(result):
+        return result
+
+    return None
+
+
+def process_get_message_activity_sent(data: dict) -> Optional[tuple[list[TextActivity], PageInfo]]:
+    return process_get_message_activity(data)  # Currently they are the same

--- a/anilist/sync_client.py
+++ b/anilist/sync_client.py
@@ -43,6 +43,12 @@ from .utils import (
 )
 
 
+def api_query(query, variables, url=API_URL, headers=HEADERS):
+    with httpx.Client(http2=True) as session:
+        response = session.post(url=url, json=dict(query=query, variables=variables), headers=headers)
+    return response
+
+
 class Client:
     def __init__(self):
         self.httpx = None
@@ -195,208 +201,79 @@ class Client:
         else:
             raise TypeError("There is no such content type.")
 
-    def search_anime(self, query: str, limit: int, page: int = 1) -> Optional[tuple[list[Anime], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=ANIME_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                    MediaType="ANIME",
-                ),
-            ),
-            headers=HEADERS,
-        )
-
+    @staticmethod
+    def search_anime(query: str, limit: int, page: int = 1) -> Optional[tuple[list[Anime], PageInfo]]:
+        response = api_query(ANIME_SEARCH_QUERY, dict(search=query, page=page, per_page=limit, MediaType="ANIME"))
         data: Optional[dict] = response.json()
         return process_search_anime(data)
 
-    def search_manga(self, query: str, limit: int, page: int = 1) -> Optional[tuple[list[Manga], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MANGA_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                    MediaType="MANGA",
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def search_manga(query: str, limit: int, page: int = 1) -> Optional[tuple[list[Manga], PageInfo]]:
+        response = api_query(MANGA_SEARCH_QUERY, dict(search=query, page=page, per_page=limit, MediaType="MANGA"))
         data = response.json()
         return process_search_manga(data)
 
-    def search_character(
-            self, query: str, limit: int, page: int = 1
-    ) -> Optional[tuple[list[Character], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=CHARACTER_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def search_character(query: str, limit: int, page: int = 1) -> Optional[tuple[list[Character], PageInfo]]:
+        response = api_query(CHARACTER_SEARCH_QUERY, dict(search=query, page=page, per_page=limit))
         data = response.json()
         return process_search_character(data)
 
-    def search_staff(self, query: str, limit: int, page: int = 1) -> Optional[tuple[list[Staff], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=STAFF_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def search_staff(query: str, limit: int, page: int = 1) -> Optional[tuple[list[Staff], PageInfo]]:
+        response = api_query(STAFF_SEARCH_QUERY, dict(search=query, page=page, per_page=limit))
         data = response.json()
         return process_search_staff(data)
 
-    def search_user(self, query: str, limit: int, page: int = 1) -> Optional[tuple[list[User], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=USER_SEARCH_QUERY,
-                variables=dict(
-                    search=query,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def search_user(query: str, limit: int, page: int = 1) -> Optional[tuple[list[User], PageInfo]]:
+        response = api_query(USER_SEARCH_QUERY, dict(search=query, page=page, per_page=limit))
         data = response.json()
         return process_search_user(data)
 
-    def get_anime(self, id: int) -> Optional[Anime]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=ANIME_GET_QUERY,
-                variables=dict(
-                    id=id,
-                    MediaType="ANIME",
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def get_anime(id: int) -> Optional[Anime]:
+        response = api_query(ANIME_GET_QUERY, dict(id=id, MediaType="ANIME"))
         data = response.json()
         return process_get_anime(data)
 
-    def get_manga(self, id: int) -> Optional[Manga]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MANGA_GET_QUERY,
-                variables=dict(
-                    id=id,
-                    MediaType="MANGA",
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def get_manga(id: int) -> Optional[Manga]:
+        response = api_query(MANGA_GET_QUERY, dict(id=id, MediaType="MANGA"))
         data = response.json()
         return process_get_manga(data)
 
-    def get_character(self, id: int) -> Optional[Character]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=CHARACTER_GET_QUERY,
-                variables=dict(
-                    id=id,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def get_character(id: int) -> Optional[Character]:
+        response = api_query(CHARACTER_GET_QUERY, dict(id=id))
         data = response.json()
         return process_get_character(data)
 
-    def get_staff(self, id: int) -> Optional[Staff]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=STAFF_GET_QUERY,
-                variables=dict(
-                    id=id,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def get_staff(id: int) -> Optional[Staff]:
+        response = api_query(STAFF_GET_QUERY, dict(id=id))
         data = response.json()
         return process_get_staff(data)
 
-    def get_user(self, name: str) -> Optional[User]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=USER_GET_QUERY,
-                variables=dict(
-                    name=name,
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def get_user(name: str) -> Optional[User]:
+        response = api_query(USER_GET_QUERY, dict(name=name))
         data = response.json()
         return process_get_user(data)
 
+    @staticmethod
     def get_list(
-            self, user_id: int, limit: int, page: int = 1, content_type: str = "anime"
+            user_id: int, limit: int, page: int = 1, content_type: str = "anime"
     ) -> Optional[tuple[list[MediaList], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-
         is_manga = "manga" in content_type
-
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=LIST_GET_QUERY_ANIME if not is_manga else LIST_GET_QUERY_MANGA,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = api_query(LIST_GET_QUERY_ANIME if not is_manga else LIST_GET_QUERY_MANGA,
+                             dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
         return process_get_list(data, content_type)
 
-    def get_list_item(self, name: str, id: int) -> Optional[MediaList]:
-        """Returns list item from user.
+    @staticmethod
+    def get_list_item(name: str, id: int) -> Optional[MediaList]:
+        """Returns an item in a list item from user.
 
         Args:
             name (str): Username.
@@ -405,19 +282,7 @@ class Client:
         Returns:
             Optional[MediaList]: List item.
         """
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=LIST_ITEM_GET_QUERY,
-                variables=dict(
-                    name=name,
-                    id=id,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = api_query(LIST_ITEM_GET_QUERY, dict(name=name, d=id))
         data = response.json()
         return process_get_list_item(data)
 
@@ -481,108 +346,45 @@ class Client:
             return activity, pages
         return activity
 
-    def get_anime_activity(
-            self, user_id: int, limit: int, page: int = 1
-    ) -> Optional[tuple[list[ListActivity], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=LIST_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                    activity_type="ANIME_LIST",
-                ),
-            ),
-            headers=HEADERS,
-        )
+    @staticmethod
+    def get_anime_activity(user_id: int, limit: int, page: int = 1) \
+            -> Optional[tuple[list[ListActivity], PageInfo]]:
+        response = api_query(LIST_ACTIVITY_QUERY,
+                             dict(user_id=user_id, page=page, per_page=limit, activity_type="ANIME_LIST"))
         data = response.json()
         return process_get_anime_activity(data)
 
-    def get_manga_activity(
-            self, user_id: int, limit: int, page: int = 1
-    ) -> Optional[tuple[list[ListActivity], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
+    @staticmethod
+    def get_manga_activity(user_id: int, limit: int, page: int = 1) \
+            -> Optional[tuple[list[ListActivity], PageInfo]]:
         MANGA_ACTIVITY_QUERY = LIST_ACTIVITY_QUERY.replace(
             "episodes", "chapters\nvolumes"
         )
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MANGA_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                    activity_type="MANGA_LIST",
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = api_query(MANGA_ACTIVITY_QUERY,
+                             dict(user_id=user_id, page=page, per_page=limit, activity_type="MANGA_LIST"))
         data = response.json()
         return process_get_manga_activity(data)
 
+    @staticmethod
     def get_text_activity(
-            self, user_id: int, limit: int, page: int = 1
+            user_id: int, limit: int, page: int = 1
     ) -> Optional[tuple[list[TextActivity], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=TEXT_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = api_query(TEXT_ACTIVITY_QUERY, dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
         return process_get_text_activity(data)
 
+    @staticmethod
     def get_message_activity(
-            self, user_id: int, limit: int, page: int = 1
+            user_id: int, limit: int, page: int = 1
     ) -> Optional[tuple[list[TextActivity], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MESSAGE_ACTIVITY_QUERY,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
+        response = api_query(MESSAGE_ACTIVITY_QUERY, dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
         return process_get_message_activity(data)
 
+    @staticmethod
     def get_message_activity_sent(
-            self, user_id: int, limit: int, page: int = 1
+            user_id: int, limit: int, page: int = 1
     ) -> Optional[tuple[list[TextActivity], PageInfo]]:
-        if not self.httpx:
-            self.httpx = httpx.Client()
-        response = self.httpx.post(
-            url=API_URL,
-            json=dict(
-                query=MESSAGE_ACTIVITY_QUERY_SENT,
-                variables=dict(
-                    user_id=user_id,
-                    page=page,
-                    per_page=limit,
-                ),
-            ),
-            headers=HEADERS,
-        )
-
+        response = api_query(MESSAGE_ACTIVITY_QUERY_SENT, dict(user_id=user_id, page=page, per_page=limit))
         data = response.json()
         return process_get_message_activity_sent(data)

--- a/anilist/sync_client.py
+++ b/anilist/sync_client.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Tuple, Union
 
 import httpx
 
-from anilist.types import (
+from .types import (
     Anime,
     Character,
     FavouritesUnion,
@@ -23,7 +23,7 @@ from anilist.types import (
     TextActivity,
     User,
 )
-from anilist.utils import (
+from .utils import (
     ANIME_GET_QUERY,
     ANIME_SEARCH_QUERY,
     API_URL,

--- a/anilist/types/activity.py
+++ b/anilist/types/activity.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, List, Optional, Union
 from .anime import Anime
 from .date import Date
 from .manga import Manga
+from .object import Hashable
 from .user import User
 
 
@@ -83,7 +84,7 @@ class ListActivityStatus:
         )
 
 
-class ListActivity:
+class ListActivity(Hashable):
     """List activity object.
 
     Args:
@@ -121,17 +122,8 @@ class ListActivity:
         if media:
             self.media = media
 
-    def raw(self) -> Dict:
-        return self.__dict__
 
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
-
-
-class TextActivity:
+class TextActivity(Hashable):
     """Text activity object.
 
     Args:
@@ -179,12 +171,3 @@ class TextActivity:
             self.url = url
         if recipient:
             self.recipient = recipient
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/anime.py
+++ b/anilist/types/anime.py
@@ -9,6 +9,7 @@ from .character import Character
 from .cover import Cover
 from .date import Date
 from .next_airing import NextAiring
+from .object import Hashable
 from .score import Score
 from .season import Season
 from .staff import Staff
@@ -17,7 +18,7 @@ from .title import Title
 from .trailer import Trailer
 
 
-class Anime:
+class Anime(Hashable):
     """Anime object."""
 
     def __init__(
@@ -180,12 +181,3 @@ class Anime:
                 )
                 for relation in relations["edges"]
             ]
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/character.py
+++ b/anilist/types/character.py
@@ -8,9 +8,10 @@ from typing import Callable, Dict
 from .date import Date
 from .image import Image
 from .name import Name
+from .object import Hashable
 
 
-class Character:
+class Character(Hashable):
     """Character object."""
 
     def __init__(
@@ -60,12 +61,3 @@ class Character:
             self.gender = gender
         if is_favorite is not None:
             self.is_favorite = is_favorite
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/cover.py
+++ b/anilist/types/cover.py
@@ -5,8 +5,10 @@
 
 from typing import Callable, Dict
 
+from .object import Object
 
-class Cover:
+
+class Cover(Object):
     """Cover object. Contains URL's for each size."""
 
     def __init__(
@@ -23,11 +25,6 @@ class Cover:
         if extra_large:
             self.extra_large = extra_large
 
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
+    def __eq__(self, other) -> bool:
+        if isinstance(other, self.__class__):
+            return self.__repr__() == other.__repr__()

--- a/anilist/types/favourites.py
+++ b/anilist/types/favourites.py
@@ -17,14 +17,25 @@ class FavouritesUnion:
     favourites of a user."""
 
     def __init__(
-        self,
-        *,
-        anime: List[Anime] = [],
-        manga: List[Manga] = [],
-        characters: List[Character] = [],
-        staff: List[Staff] = [],
-        studios: List[Studio] = [],
+            self,
+            *,
+            anime: List[Anime] = None,
+            manga: List[Manga] = None,
+            characters: List[Character] = None,
+            staff: List[Staff] = None,
+            studios: List[Studio] = None,
     ) -> None:
+        if not anime:
+            anime = []
+        if not manga:
+            manga = []
+        if not characters:
+            characters = []
+        if not staff:
+            staff = []
+        if not studios:
+            studios = []
+
         self.anime = anime
         self.manga = manga
         self.characters = characters

--- a/anilist/types/favourites.py
+++ b/anilist/types/favourites.py
@@ -8,10 +8,11 @@ from typing import Callable, Dict, List
 from .anime import Anime
 from .character import Character
 from .manga import Manga
+from .object import Object
 from .staff import Staff, Studio
 
 
-class FavouritesUnion:
+class FavouritesUnion(Object):
     """Favourites union containing all
     anime, manga, character, staff and studio
     favourites of a user."""
@@ -42,11 +43,8 @@ class FavouritesUnion:
         self.staff = staff
         self.studios = studios
 
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
+    def __eq__(self, other) -> bool:
+        if isinstance(other, self.__class__):
+            if ((self.anime, self.manga, self.characters, self.staff, self.studios) ==
+                    (other.anime, other.manga, other.characters, other.staff, other.studios)):
+                return True

--- a/anilist/types/image.py
+++ b/anilist/types/image.py
@@ -5,8 +5,10 @@
 
 from typing import Callable, Dict
 
+from .object import Object
 
-class Image:
+
+class Image(Object):
     """Image object."""
 
     def __init__(
@@ -20,11 +22,6 @@ class Image:
         if large:
             self.large = large
 
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.raw() == other.raw()

--- a/anilist/types/manga.py
+++ b/anilist/types/manga.py
@@ -9,6 +9,7 @@ from .character import Character
 from .cover import Cover
 from .date import Date
 from .next_airing import NextAiring
+from .object import Hashable
 from .score import Score
 from .season import Season
 from .staff import Staff
@@ -17,7 +18,7 @@ from .title import Title
 from .trailer import Trailer
 
 
-class Manga:
+class Manga(Hashable):
     """Manga object."""
 
     def __init__(
@@ -177,12 +178,3 @@ class Manga:
                 )
                 for relation in relations["edges"]
             ]
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/medialist.py
+++ b/anilist/types/medialist.py
@@ -8,9 +8,10 @@ from typing import Callable, Dict, Union
 from .anime import Anime
 from .date import Date
 from .manga import Manga
+from .object import Hashable
 
 
-class MediaList:
+class MediaList(Hashable):
     """List item containing state of a entry in a user's list."""
 
     def __init__(
@@ -57,12 +58,3 @@ class MediaList:
             self.create_date = Date.from_timestamp(create_date)
         if media:
             self.media = media
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/name.py
+++ b/anilist/types/name.py
@@ -5,8 +5,10 @@
 
 from typing import Callable, Dict
 
+from .object import Object
 
-class Name:
+
+class Name(Object):
     """Name object."""
 
     def __init__(
@@ -28,12 +30,3 @@ class Name:
             self.last = last
         if alternative:
             self.alternative = alternative
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/next_airing.py
+++ b/anilist/types/next_airing.py
@@ -6,9 +6,10 @@
 from typing import Callable, Dict
 
 from .date import Date
+from .object import Object
 
 
-class NextAiring:
+class NextAiring(Object):
     """Status of an airing anime."""
 
     def __init__(
@@ -24,12 +25,3 @@ class NextAiring:
             self.at = Date.from_timestamp(at)
         if episode:
             self.episode = episode
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/object.py
+++ b/anilist/types/object.py
@@ -1,0 +1,28 @@
+from typing import Dict
+
+
+class Object:
+    __slots__ = ()
+
+    def raw(self) -> Dict:
+        return self.__dict__
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __str__(self) -> str:
+        return str(self.raw())
+
+
+class Hashable(Object):
+    __slots__ = ()
+
+    id: int
+
+    def __hash__(self) -> int:
+        return hash((type(self), self.id))
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, self.__class__):
+            return other.id == self.id
+        return NotImplemented

--- a/anilist/types/page.py
+++ b/anilist/types/page.py
@@ -5,8 +5,10 @@
 
 from typing import Callable, Dict
 
+from .object import Object
 
-class PageInfo:
+
+class PageInfo(Object):
     """Page object. Contains Pagination info."""
 
     def __init__(
@@ -19,12 +21,3 @@ class PageInfo:
         self.total_items = total_items
         self.current = current
         self.last = last
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/score.py
+++ b/anilist/types/score.py
@@ -5,8 +5,10 @@
 
 from typing import Callable, Dict
 
+from .object import Object
 
-class Score:
+
+class Score(Object):
     """Mean and average score union."""
 
     def __init__(
@@ -19,12 +21,3 @@ class Score:
             self.mean = mean
         if average:
             self.average = average
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/season.py
+++ b/anilist/types/season.py
@@ -5,9 +5,11 @@
 
 from typing import Callable, Dict
 
+from .object import Object
 
-class Season:
-    """Season object that represents a seson."""
+
+class Season(Object):
+    """Season object that represents a season."""
 
     def __init__(
         self,
@@ -23,11 +25,10 @@ class Season:
         if number:
             self.number = number
 
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
+    def __eq__(self, other) -> bool:
+        if isinstance(other, self.__class__):
+            if (self.name, self.year, self.number) == (other.name, other.year, other.number):
+                return True
+            
+    def __hash__(self) -> int:
+        return hash((self.name, self.year, self.number))

--- a/anilist/types/staff.py
+++ b/anilist/types/staff.py
@@ -3,14 +3,15 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import Callable, Dict, List
+from typing import Dict, List
 
 from .date import Date
 from .image import Image
 from .name import Name
+from .object import Hashable
 
 
-class Studio:
+class Studio(Hashable):
     """Studio object."""
 
     def __init__(
@@ -31,7 +32,7 @@ class Studio:
             self.favourites = favourites
 
 
-class Staff:
+class Staff(Hashable):
     """Staff object."""
 
     def __init__(
@@ -97,12 +98,3 @@ class Staff:
             self.home_town = home_town
         if is_favorite is not None:
             self.is_favorite = is_favorite
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/statistics.py
+++ b/anilist/types/statistics.py
@@ -5,10 +5,11 @@
 
 from typing import Callable, Dict, List
 
+from .object import Object
 from .score import Score
 
 
-class Ranking:
+class Ranking(Object):
     """Ranking of a media object."""
 
     def __init__(
@@ -30,17 +31,8 @@ class Ranking:
         if season:
             self.season = season
 
-    def raw(self) -> Dict:
-        return self.__dict__
 
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
-
-
-class Statistic:
+class Statistic(Object):
     """Statistic object of a user."""
 
     def __init__(
@@ -69,28 +61,10 @@ class Statistic:
         if tags:
             self.tags = tags
 
-    def raw(self) -> Dict:
-        return self.__dict__
 
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
-
-
-class StatisticsUnion:
+class StatisticsUnion(Object):
     """Union containing anime and manga statistics of a user."""
 
     def __init__(self, *, anime: Statistic, manga: Statistic) -> None:
         self.anime = anime
         self.manga = manga
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/statistics.py
+++ b/anilist/types/statistics.py
@@ -44,9 +44,9 @@ class Statistic(Object):
         episodes_watched: int = None,
         chapters_read: int = None,
         volumes_read: int = None,
-        statuses: List[Dict[str, int]] = None,
-        genres: List[Dict[str, int]] = None,
-        tags: List[Dict[str, int]] = None,
+        statuses: list[list[dict[str, int], dict[str, int]]] = None,
+        genres: list[list[dict[str, int], dict[str, int]]] = None,
+        tags: list[list[dict[str, int], dict[str, int]]] = None,
     ) -> None:
         self.count = count
         self.mean_score = mean_score

--- a/anilist/types/title.py
+++ b/anilist/types/title.py
@@ -5,8 +5,10 @@
 
 from typing import Callable, Dict
 
+from .object import Object
 
-class Title:
+
+class Title(Object):
     """Title object."""
 
     def __init__(
@@ -23,11 +25,6 @@ class Title:
         if native:
             self.native = native
 
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())
+    def __eq__(self, other) -> bool:
+        if isinstance(other, self.__class__):
+            return str(self) == str(other)

--- a/anilist/types/trailer.py
+++ b/anilist/types/trailer.py
@@ -5,8 +5,10 @@
 
 from typing import Callable, Dict
 
+from .object import Hashable
 
-class Trailer:
+
+class Trailer(Hashable):
     """Contains data for anime trailers."""
 
     def __init__(
@@ -24,12 +26,3 @@ class Trailer:
             self.site = site
             if site == "youtube":
                 self.url = f"https://youtu.be/{id}"
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/anilist/types/user.py
+++ b/anilist/types/user.py
@@ -8,7 +8,7 @@ from typing import Callable, Dict, Tuple
 from .date import Date
 from .favourites import FavouritesUnion
 from .image import Image
-from .name import Name
+from .object import Hashable
 from .statistics import StatisticsUnion
 
 
@@ -42,7 +42,7 @@ def get_profile_color(color: str) -> Tuple[int, int, int]:
         return 255, 255, 255
 
 
-class User:
+class User(Hashable):
     """User object."""
 
     def __init__(
@@ -83,12 +83,3 @@ class User:
             self.donator_badge = donator_badge
         if profile_color:
             self.profile_color = get_profile_color(profile_color)
-
-    def raw(self) -> Dict:
-        return self.__dict__
-
-    def __repr__(self) -> Callable:
-        return self.__str__()
-
-    def __str__(self) -> str:
-        return str(self.raw())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--cov=pythonanilist"
+addopts = "--cov=python-anilist"
 testpaths = [
     "tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--cov=python-anilist"
+addopts = "--cov=pythonanilist"
 testpaths = [
     "tests",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 
 [metadata]
 name = python-anilist
-version = 1.0.9
+version = 1.1.0
 url = https://github.com/AmanoTeam/python-anilist
 author = AmanoTeam
 author_email = contact@amanoteam.com

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -48,8 +48,8 @@ async def test_get(id, content_type):
 @pytest.mark.asyncio
 async def test_get_list_item():
     client = anilist.AsyncClient()
-    assert await client.get_list_item("travis", "5081") is not None
-    assert await client.get_list_item("travis", "72451") is not None
+    assert await client.get_list_item("travis", 132405) is not None
+    assert await client.get_list_item("travis", 30) is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -45,8 +45,8 @@ def test_get(id, content_type):
 
 def test_get_list_item():
     client = anilist.Client()
-    assert client.get_list_item("travis", "5081") is not None
-    assert client.get_list_item("travis", "72451") is not None
+    assert client.get_list_item("travis", 132405) is not None
+    assert client.get_list_item("travis", 30) is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hello, thank you for your wonderful library. It's very well made and works well. I've written in the changelog file but I'll write it again here. 

I spent some time just consolidating a lot of duplicated code:

- Every class was defined with duplicate definitions of `raw()`, `__repr__()`, and `__str__()`, so I moved all those to a base class called `Object` and had the anilist classes derive from that. Additionally, if a class has an ID, I made a `Hashable` type as a subclass of `Object` which implemented `__eq__()` and `__hash__()`. 
- The logic for API calls in every class was duplicated, so I moved it all to one function, `api_query()` and had all functions call that instead.
- The data analysis and packaging of the information received from the response was mostly duplicated between the `sync_client.py` file and the `async_client.py` for the purpose of having different logic in the api query step, but I moved all the steps that were the same for both files out into a third external file `client_process.py` so they can be called equally.

--------------------


One change I made that technically could be breaking is I removed the mass ignoring of exceptions in the data packaging code. There were many instances of code like:
```py
try:
    # code here
except Exception:
    pass
```
This probably isn't good because it hides errors which can lead to both complications in debugging and unintended behavior in production. For now, I left the structure of the code the same and just changed "pass" to "raise". To undo this change, one can do a substitution operation in `client_process.py` to replace "raise" back to "pass".

------------------

Finally, I fixed what I believe to be an error but I'm technically not sure. In the function `get_message_activity()` 

https://github.com/AmanoTeam/python-anilist/blob/a21b26b1baf6e134eeac8b9251346a9bcbef2d19/anilist/sync_client.py#L1271

it looks like there are two functions inside the one definition, and the function starts over with a new query call here: 
https://github.com/AmanoTeam/python-anilist/blob/a21b26b1baf6e134eeac8b9251346a9bcbef2d19/anilist/sync_client.py#L1322

so I split the function into `get_message_activity()` and `get_message_activity_sent()`.

https://github.com/r-hensley/python-anilist/blob/f9183a0656d5db8a9da68902f36dc67c355201ab/anilist/sync_client.py#L376-390

--------------------

I ran all the tests and (after changing one obsolete ID in one of the tests), confirmed they all passed:
```py
C:\Users\ryry0\AppData\Local\Programs\Python\Python310\python.exe "C:\Program Files\JetBrains\PyCharm 2022.1.3\plugins\python\helpers\pycharm\_jb_pytest_runner.py" --path C:/Users/ryry0/Documents/Python/anime_staff_checker/pythonanilist/tests/test_sync.py
Testing started at 11:54 PM ...
Launching pytest with arguments C:/Users/ryry0/Documents/Python/anime_staff_checker/pythonanilist/tests/test_sync.py --no-header --no-summary -q in C:\Users\ryry0\Documents\Python\anime_staff_checker\pythonanilist\tests

============================= test session starts =============================
collecting ... collected 16 items

test_sync.py::test_search[Bakemonogatari-anime] 
test_sync.py::test_search[Bakemonogatari-manga] 
test_sync.py::test_search[Senjougahara-character] 
test_sync.py::test_search[Chiwa Saitou-staff] 
test_sync.py::test_search[travis-user] 
test_sync.py::test_get[5081-anime] 
test_sync.py::test_get[101311-manga] 
test_sync.py::test_get[22037-character] 
test_sync.py::test_get[95061-staff] 
test_sync.py::test_get[travis-user] 
test_sync.py::test_get[travis-list_anime] 
test_sync.py::test_get[travis-list_manga] 
test_sync.py::test_get_list_item 
test_sync.py::test_get_activity[travis-anime] 
test_sync.py::test_get_activity[travis-manga] 
test_sync.py::test_get_activity[travis-text] 

============================= 16 passed in 13.78s =============================

Process finished with exit code 0
```
```py
C:\Users\ryry0\AppData\Local\Programs\Python\Python310\python.exe "C:\Program Files\JetBrains\PyCharm 2022.1.3\plugins\python\helpers\pycharm\_jb_pytest_runner.py" --path C:/Users/ryry0/Documents/Python/anime_staff_checker/pythonanilist/tests/test_async.py
Testing started at 11:54 PM ...
Launching pytest with arguments C:/Users/ryry0/Documents/Python/anime_staff_checker/pythonanilist/tests/test_async.py --no-header --no-summary -q in C:\Users\ryry0\Documents\Python\anime_staff_checker\pythonanilist\tests

============================= test session starts =============================
collecting ... collected 16 items

test_async.py::test_search[Bakemonogatari-anime] 
test_async.py::test_search[Bakemonogatari-manga] 
test_async.py::test_search[Senjougahara-character] 
test_async.py::test_search[Chiwa Saitou-staff] 
test_async.py::test_search[travis-user] 
test_async.py::test_get[5081-anime] 
test_async.py::test_get[101311-manga] 
test_async.py::test_get[22037-character] 
test_async.py::test_get[95061-staff] 
test_async.py::test_get[travis-user] 
test_async.py::test_get[travis-list_anime] 
test_async.py::test_get[travis-list_manga] 
test_async.py::test_get_list_item 
test_async.py::test_get_activity[travis-anime] 
test_async.py::test_get_activity[travis-manga] 
test_async.py::test_get_activity[travis-text] 

============================= 16 passed in 12.91s =============================

Process finished with exit code 0
```

Overall, I reduced:

- `sync_client.py`: 1,370 lines → 390 lines
- `async_client.py`: 1,463 lines → 407 lines
- `client_process.py` (NEW): 0 lines → 703 lines
 
Tell me if you have any questions.